### PR TITLE
Implement extra tools for Supabase MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This project provides a minimal implementation of a Model Context Protocol (MCP) server that talks to Supabase. It follows the specifications described in `docs/quickstart.md`.
 
+Supported tools now include:
+
+- `list_projects`
+- `execute_sql`
+- `list_tables`
+- `list_extensions`
+- `list_organizations`
+- `get_project_url`
+- `get_anon_key`
+
 ## Usage
 
 Run with npx:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,16 @@ Run in development:
 npm run dev -- --access-token YOUR_PAT --project-ref your-project
 ```
 
+Available tools after startup:
+
+- `list_projects`
+- `execute_sql`
+- `list_tables`
+- `list_extensions`
+- `list_organizations`
+- `get_project_url`
+- `get_anon_key`
+
 Docker image:
 ```bash
 docker build -t supabase-mcp .

--- a/packages/tools-supabase/index.ts
+++ b/packages/tools-supabase/index.ts
@@ -4,6 +4,22 @@ import pg from 'pg'
 
 export const router = new Router()
 
+// list_organizations
+export const listOrganizationsParams = z.object({})
+router.register('list_organizations', async (_p: unknown, ctx: Context) => {
+  const resp = await fetch('https://api.supabase.com/v1/organizations', {
+    headers: {
+      Authorization: `Bearer ${ctx.accessToken}`,
+      'X-Client-Info': `supabase-mcp@${process.env.npm_package_version}`,
+    },
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  return resp.json()
+})
+
+const listOrganizationsSchema: HelloAction = {
+  parameters: { type: 'object', properties: {} },
+}
 // list_projects
 export const listProjectsParams = z.object({})
 router.register('list_projects', async (_params: unknown, ctx: Context) => {
@@ -62,10 +78,121 @@ const executeSqlSchema: HelloAction = {
   dangerous: true,
 }
 
-export type ToolNames = 'list_projects' | 'execute_sql'
-export const actions: ToolNames[] = ['list_projects', 'execute_sql']
+// list_tables
+export const listTablesParams = z.object({})
+router.register('list_tables', async (_params: unknown, ctx: Context) => {
+  if (!ctx.projectRef) throw new Error('projectRef required')
+  const pool = new pg.Pool({
+    host: `${ctx.projectRef}.supabase.co`,
+    user: 'supabase_read_only',
+    ssl: { rejectUnauthorized: false },
+  })
+  const client = await pool.connect()
+  try {
+    const result = await client.query(
+      "SELECT table_name FROM information_schema.tables WHERE table_schema='public' ORDER BY table_name"
+    )
+    return result.rows.map(r => r.table_name)
+  } finally {
+    client.release()
+    await pool.end()
+  }
+})
+
+const listTablesSchema: HelloAction = {
+  parameters: { type: 'object', properties: {} },
+}
+
+// list_extensions
+export const listExtensionsParams = z.object({})
+router.register('list_extensions', async (_params: unknown, ctx: Context) => {
+  if (!ctx.projectRef) throw new Error('projectRef required')
+  const pool = new pg.Pool({
+    host: `${ctx.projectRef}.supabase.co`,
+    user: 'supabase_read_only',
+    ssl: { rejectUnauthorized: false },
+  })
+  const client = await pool.connect()
+  try {
+    const result = await client.query(
+      'SELECT name, installed_version FROM pg_available_extensions WHERE installed_version IS NOT NULL'
+    )
+    return result.rows
+  } finally {
+    client.release()
+    await pool.end()
+  }
+})
+
+const listExtensionsSchema: HelloAction = {
+  parameters: { type: 'object', properties: {} },
+}
+
+// get_project_url
+export const getProjectUrlParams = z.object({})
+router.register('get_project_url', async (_p: unknown, ctx: Context) => {
+  if (!ctx.projectRef) throw new Error('projectRef required')
+  const resp = await fetch(`https://api.supabase.com/v1/projects/${ctx.projectRef}`, {
+    headers: {
+      Authorization: `Bearer ${ctx.accessToken}`,
+      'X-Client-Info': `supabase-mcp@${process.env.npm_package_version}`,
+    },
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  const data = await resp.json()
+  return data.api.restUrl
+})
+
+const getProjectUrlSchema: HelloAction = {
+  parameters: { type: 'object', properties: {} },
+}
+
+// get_anon_key
+export const getAnonKeyParams = z.object({})
+router.register('get_anon_key', async (_p: unknown, ctx: Context) => {
+  if (!ctx.projectRef) throw new Error('projectRef required')
+  const resp = await fetch(`https://api.supabase.com/v1/projects/${ctx.projectRef}`, {
+    headers: {
+      Authorization: `Bearer ${ctx.accessToken}`,
+      'X-Client-Info': `supabase-mcp@${process.env.npm_package_version}`,
+    },
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  const data = await resp.json()
+  return data.api.anon
+})
+
+const getAnonKeySchema: HelloAction = {
+  parameters: { type: 'object', properties: {} },
+}
+
+export type ToolNames =
+  | 'list_projects'
+  | 'execute_sql'
+  | 'list_tables'
+  | 'list_extensions'
+  | 'list_organizations'
+  | 'get_project_url'
+  | 'get_anon_key'
+
+export const actions: ToolNames[] = [
+  'list_projects',
+  'execute_sql',
+  'list_tables',
+  'list_extensions',
+  'list_organizations',
+  'get_project_url',
+  'get_anon_key',
+]
+
 export const actionSpecs: Record<ToolNames, HelloAction> = {
   list_projects: listProjectsSchema,
   execute_sql: executeSqlSchema,
+  list_tables: listTablesSchema,
+  list_extensions: listExtensionsSchema,
+  list_organizations: listOrganizationsSchema,
+  get_project_url: getProjectUrlSchema,
+  get_anon_key: getAnonKeySchema,
 }
+
 


### PR DESCRIPTION
## Summary
- expose more Supabase tools
- document available tools in README and quickstart

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d7d3feb4832da1ac106ce5b31691